### PR TITLE
feat: push_and_transform API

### DIFF
--- a/benches/pareto_element/mod.rs
+++ b/benches/pareto_element/mod.rs
@@ -1,8 +1,6 @@
 //! Element types that used to run the `ParetoFront` benchmarks
 #![allow(dead_code)]
 mod random;
-pub use random::ParetoElementRandom;
 mod circle;
 pub use circle::ParetoElementCircle;
 mod circle5d;
-pub use circle5d::ParetoElementCircle5D;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,38 +3,40 @@ use pareto_front::{Dominate, ParetoFront};
 
 /// test element
 #[derive(Debug, PartialEq)]
-struct ParetoElement
-{
-    cost: usize,
-    quality: f32,
-    score: i64
+struct ParetoElement {
+    partial_data: i32,
+    rest_of_the_data: Option<i32>,
 }
 
 /// implement the `Dominate` trait
-impl Dominate for ParetoElement
-{
-    fn dominate(&self, x: &Self) -> bool
-    {
-        (self.cost <= x.cost) && (self.quality >= x.quality) && (self.score >= x.score) && (self != x)
+impl Dominate for ParetoElement {
+    fn dominate(&self, x: &Self) -> bool {
+        self.partial_data < x.partial_data
     }
 }
 
-fn main()
-{
+fn main() {
     // data to be put in the front
-    let x = ParetoElement { cost: 35, quality: 0.5, score: 4 };
-    let y = ParetoElement { cost: 350, quality: 0.05, score: 2 };
-    let z = ParetoElement { cost: 5, quality: 0.25, score: 5 };
+    let x = ParetoElement { partial_data: 1, rest_of_the_data: None };
+    let y = ParetoElement { partial_data: 2, rest_of_the_data: None };
+    let z = ParetoElement { partial_data: 3, rest_of_the_data: None };
 
     // insertions in the front
     let mut front = ParetoFront::new();
-    front.push(x);
-    front.push(y);
-    front.push(z);
+
+    fn compute_rest_expensively(pareto_element: &mut ParetoElement) -> bool {
+        // Pretend this is super expensive
+        pareto_element.rest_of_the_data =
+            if pareto_element.partial_data % 2 == 0 { Some(pareto_element.partial_data * 2) } else { None };
+        pareto_element.rest_of_the_data.is_some()
+    }
+
+    front.push_and_check(x, compute_rest_expensively);
+    front.push_and_check(y, compute_rest_expensively);
+    front.push_and_check(z, compute_rest_expensively);
 
     // display of the result
-    for (i, element) in front.iter().enumerate()
-    {
+    for (i, element) in front.iter().enumerate() {
         println!("{}: {:?}", i, element);
     }
 }

--- a/src/pareto_front_implementation/pareto_front.rs
+++ b/src/pareto_front_implementation/pareto_front.rs
@@ -145,7 +145,7 @@ impl<T: Dominate> ParetoFront<T>
         }
         // for all the elements in the largest front, remove dominated elements from the smallest front
         // keep only the elements that should be in the Pareto front
-        largest_front = largest_front.into_iter().filter(|x| self._remove_dominated(x)).collect();
+        largest_front.retain(|x| self._remove_dominated(x));
         // extends the largest front with the content of the smallest front
         // and make it our front
         std::mem::swap(&mut self.front, &mut largest_front);
@@ -171,7 +171,7 @@ impl<T: Dominate> ParetoFront<T>
     }
 
     /// Returns an iterator over the Pareto front.
-    pub fn iter(&self) -> Iter<T>
+    pub fn iter<'a>(&'a self) -> Iter<'a, T>
     {
         self.front.iter()
     }

--- a/src/pareto_front_implementation/pareto_front.rs
+++ b/src/pareto_front_implementation/pareto_front.rs
@@ -48,7 +48,7 @@ impl<T: Dominate> ParetoFront<T>
     /// but is optimized to favour early stopping and cache friendly.
     ///
     /// This operation might *not* preserve the ordering of the elements in the front.
-    fn _remove_dominated(&mut self, new_element: &T) -> bool
+    pub fn remove_dominated(&mut self, new_element: &T) -> bool
     {
         // for all elements of the pareto front, check whether they are dominated or dominate `new_element`
         for (index, element) in self.front.iter().enumerate()
@@ -120,7 +120,7 @@ impl<T: Dominate> ParetoFront<T>
     pub fn push(&mut self, new_element: T) -> bool
     {
         // removes dominated elements from the front and checks whether `new_element` should be added
-        let is_pareto_optimal = self._remove_dominated(&new_element);
+        let is_pareto_optimal = self.remove_dominated(&new_element);
         // adds `new_element` if needed
         if is_pareto_optimal
         {
@@ -145,7 +145,7 @@ impl<T: Dominate> ParetoFront<T>
         }
         // for all the elements in the largest front, remove dominated elements from the smallest front
         // keep only the elements that should be in the Pareto front
-        largest_front.retain(|x| self._remove_dominated(x));
+        largest_front.retain(|x| self.remove_dominated(x));
         // extends the largest front with the content of the smallest front
         // and make it our front
         std::mem::swap(&mut self.front, &mut largest_front);

--- a/src/pareto_front_implementation/pareto_front.rs
+++ b/src/pareto_front_implementation/pareto_front.rs
@@ -119,19 +119,54 @@ impl<T: Dominate> ParetoFront<T>
     /// ```
     pub fn push(&mut self, new_element: T) -> bool
     {
-        self.push_and_transform(new_element, |x| x)
-    }
-
-    pub fn push_and_transform(&mut self, new_element: T, transform: impl FnOnce(T) -> T) -> bool
-    {
         // removes dominated elements from the front and checks whether `new_element` should be added
         let is_pareto_optimal = self._remove_dominated(&new_element);
         // adds `new_element` if needed
         if is_pareto_optimal
         {
-            self.front.push((transform)(new_element));
+            self.front.push(new_element);
         }
         is_pareto_optimal
+    }
+
+    // TODO: doc comments. I will write this if this is the correct approach
+    pub fn push_and_check(&mut self, mut new_element: T, mut check: impl FnMut(&mut T) -> bool) -> bool
+    {
+        // for all elements of the pareto front, check whether they are dominated or dominate `new_element`
+        for (index, element) in self.front.iter().enumerate()
+        {
+            if element.dominate(&new_element)
+            {
+                // `new_element` is dominated by `element`, it is thus not part of the Pareto front
+                // swap `element` with the previous element in order to percolate the best elements to the top
+                // NOTE: in my benchmarks this brings clear performance benefits by putting "killer" elements first
+                if index > 0
+                {
+                    self.front.swap(index, index - 1);
+                }
+                return false;
+            }
+            else if new_element.dominate(element) && (check)(&mut new_element)
+            {
+                // `new_element` dominates `element`, it is thus part of the Pareto front
+                self.front.swap_remove(index);
+                // looks at the rest of the Pareto front to remove any further element that are dominated
+                self._remove_dominated_starting_at(&new_element, index);
+                self.front.push(new_element);
+                return true;
+            }
+        }
+
+        if (check)(&mut new_element)
+        {
+            // `new_element` has not been dominated, it is thus part of the Pareto front
+            self.front.push(new_element);
+            true
+        }
+        else
+        {
+            false
+        }
     }
 
     /// Adds the content of `pareto_front` to the Pareto front.

--- a/src/pareto_front_implementation/pareto_front.rs
+++ b/src/pareto_front_implementation/pareto_front.rs
@@ -48,7 +48,7 @@ impl<T: Dominate> ParetoFront<T>
     /// but is optimized to favour early stopping and cache friendly.
     ///
     /// This operation might *not* preserve the ordering of the elements in the front.
-    pub fn remove_dominated(&mut self, new_element: &T) -> bool
+    fn _remove_dominated(&mut self, new_element: &T) -> bool
     {
         // for all elements of the pareto front, check whether they are dominated or dominate `new_element`
         for (index, element) in self.front.iter().enumerate()
@@ -120,7 +120,7 @@ impl<T: Dominate> ParetoFront<T>
     pub fn push(&mut self, new_element: T) -> bool
     {
         // removes dominated elements from the front and checks whether `new_element` should be added
-        let is_pareto_optimal = self.remove_dominated(&new_element);
+        let is_pareto_optimal = self._remove_dominated(&new_element);
         // adds `new_element` if needed
         if is_pareto_optimal
         {
@@ -145,7 +145,7 @@ impl<T: Dominate> ParetoFront<T>
         }
         // for all the elements in the largest front, remove dominated elements from the smallest front
         // keep only the elements that should be in the Pareto front
-        largest_front.retain(|x| self.remove_dominated(x));
+        largest_front.retain(|x| self._remove_dominated(x));
         // extends the largest front with the content of the smallest front
         // and make it our front
         std::mem::swap(&mut self.front, &mut largest_front);

--- a/src/pareto_front_implementation/pareto_front.rs
+++ b/src/pareto_front_implementation/pareto_front.rs
@@ -119,12 +119,17 @@ impl<T: Dominate> ParetoFront<T>
     /// ```
     pub fn push(&mut self, new_element: T) -> bool
     {
+        self.push_and_transform(new_element, |x| x)
+    }
+
+    pub fn push_and_transform(&mut self, new_element: T, transform: impl FnOnce(T) -> T) -> bool
+    {
         // removes dominated elements from the front and checks whether `new_element` should be added
         let is_pareto_optimal = self._remove_dominated(&new_element);
         // adds `new_element` if needed
         if is_pareto_optimal
         {
-            self.front.push(new_element);
+            self.front.push((transform)(new_element));
         }
         is_pareto_optimal
     }


### PR DESCRIPTION
My use case requires something not currently possible with the publicly exported functions, hence this PR.

My pareto front data structure looks similar to this:

```rs
struct Data {
    partial_data: Foo, // Cheap to compute
    rest_of_the_data: Option<Bar>, // Expensive to compute
}
```

and the `Dominate` implementation only considers the `partial_data` field. What would be useful is for some way to check if a current instance of `Data` with a `None` value for `rest_of_the_data` should be added to the frontier, and if so initialize `rest_of_the_data`. The `push` method is not granular enough to perform this type of operation, so this PR proposes a `push_and_transform` method that takes a transformation `FnOnce` as an argument which serves to compute `rest_of_the_data`.

Lastly, I fix miscellaneous clippy suggestions.